### PR TITLE
Fix 'Invalid code point NaN' errors

### DIFF
--- a/src/DiplomacyPacket.js
+++ b/src/DiplomacyPacket.js
@@ -73,7 +73,14 @@ var OutgoingDiplomacyPacket = class OutgoingDiplomacyPacket {
         let packet = '';
         for(let data = 0; data < this.data.length; data++)
         {
-            packet += String.fromCodePoint(this.data[data]);
+            if (this.data[data] === undefined)
+            {
+                packet += String.fromCodePoint(0);
+            }
+            else
+            {
+                packet += String.fromCodePoint(this.data[data]);
+            }
         }
         console.log('Wrote ' + this.dataWritten + " bits") ;
         return packet;


### PR DESCRIPTION
Without this fix, such an error occurs when messages with a sufficient number of '0' numbers are created (with a non-zero number added to the end).

An example:
```javascript
global.diplomacyPacketTest = function () {
    const {OutgoingDiplomacyPacket} = require('DiplomacyPacket');
    let packet = new OutgoingDiplomacyPacket();
    packet.writeByte(0);
    packet.writeByte(0);
    packet.writeByte(1);
    packet.getSayMessage();
};
```
Produces:
```
> diplomacyPacketTest()
[01-23 15:02] [error] RangeError: Invalid code point NaN
    at Function.fromCodePoint (native)
    at OutgoingDiplomacyPacket.getSayMessage (DiplomacyPacket:76:30)
    at global.diplomacyPacketTest (customizations:832:16)
```

I'm not at all sure this is the best way to fix this though - it could be better to change writeBit, or to change some other part, this is mostly a notify-PR.